### PR TITLE
twisted mass removed from CompactWilsonExpClover

### DIFF
--- a/Grid/qcd/action/fermion/CompactWilsonExpCloverFermion.h
+++ b/Grid/qcd/action/fermion/CompactWilsonExpCloverFermion.h
@@ -121,7 +121,6 @@ public:
 			    GridCartesian& Fgrid,
 			    GridRedBlackCartesian& Hgrid,
 			    const RealD _mass,
-				const RealD _twmass,
 			    const RealD _csw_r = 0.0,
 			    const RealD _csw_t = 0.0,
 			    const RealD _cF = 1.0,
@@ -224,7 +223,6 @@ public:
   RealD csw_r;
   RealD csw_t;
   RealD cF;
-  RealD twmass; // Twisted-mass
 
   bool open_boundaries;
 

--- a/Grid/qcd/action/fermion/implementation/CompactWilsonExpCloverFermionImplementation.h
+++ b/Grid/qcd/action/fermion/implementation/CompactWilsonExpCloverFermionImplementation.h
@@ -337,7 +337,7 @@ void CompactWilsonExpCloverFermion<Impl>::ImportGauge(const GaugeField& _Umu) {
 
   // Possibly modify the boundary values
   double t6 = usecond();
-  if(open_boundaries) CompactHelpers::ModifyBoundaries(Diagonal, Triangle, csw_t, cF, this->diag_mass);
+  if(open_boundaries) CompactHelpers::ModifyBoundaries(DiagonalExp, TriangleExp, csw_t, cF, this->diag_mass);
 
   // Invert the clover term in the improved layout
   double t7 = usecond();

--- a/Grid/qcd/action/fermion/implementation/CompactWilsonExpCloverFermionImplementation.h
+++ b/Grid/qcd/action/fermion/implementation/CompactWilsonExpCloverFermionImplementation.h
@@ -356,19 +356,18 @@ void CompactWilsonExpCloverFermion<Impl>::ImportGauge(const GaugeField& _Umu) {
 
   // Report timings
   double t9 = usecond();
-  
-  std::cout << GridLogDebug << "CompactWilsonExpCloverFermion::ImportGauge timings:"
-            << " WilsonFermion::Importgauge = " << (t1 - t0) / 1e6
-            << ", allocations = "               << (t2 - t1) / 1e6
-            << ", field strength = "            << (t3 - t2) / 1e6
-            << ", fill clover = "               << (t4 - t3) / 1e6
-            << ", convert = "                   << (t5 - t4) / 1e6
-            << ", exponentiation = "            << (t6 - t5) / 1e6
-            << ", boundaries = "                << (t7 - t6) / 1e6
-			      << ", inversions = "                << (t8 - t7) / 1e6
-            << ", pick cbs = "                  << (t9 - t8) / 1e6
-            << ", total = "                     << (t9 - t0) / 1e6
-            << std::endl;
+
+  std::cout << GridLogDebug << "CompactWilsonExpCloverFermion::ImportGauge timings:" << std::endl;
+  std::cout << GridLogDebug << " WilsonFermion::Importgauge = " << (t1 - t0) / 1e6 << std::endl;
+  std::cout << GridLogDebug << ", allocations = "               << (t2 - t1) / 1e6 << std::endl;
+  std::cout << GridLogDebug << ", field strength = "            << (t3 - t2) / 1e6 << std::endl;
+  std::cout << GridLogDebug << ", fill clover = "               << (t4 - t3) / 1e6 << std::endl;
+  std::cout << GridLogDebug << ", convert = "                   << (t5 - t4) / 1e6 << std::endl;
+  std::cout << GridLogDebug << ", exponentiation = "            << (t6 - t5) / 1e6 << std::endl;
+  std::cout << GridLogDebug << ", boundaries = "                << (t7 - t6) / 1e6 << std::endl;
+	std::cout << GridLogDebug << ", inversions = "                << (t8 - t7) / 1e6 << std::endl;
+  std::cout << GridLogDebug << ", pick cbs = "                  << (t9 - t8) / 1e6 << std::endl;
+  std::cout << GridLogDebug << ", total = "                     << (t9 - t0) / 1e6 << std::endl;
 }
 
 NAMESPACE_END(Grid);

--- a/Grid/qcd/action/fermion/implementation/CompactWilsonExpCloverFermionImplementation.h
+++ b/Grid/qcd/action/fermion/implementation/CompactWilsonExpCloverFermionImplementation.h
@@ -359,15 +359,15 @@ void CompactWilsonExpCloverFermion<Impl>::ImportGauge(const GaugeField& _Umu) {
 
   std::cout << GridLogDebug << "CompactWilsonExpCloverFermion::ImportGauge timings:" << std::endl;
   std::cout << GridLogDebug << " WilsonFermion::Importgauge = " << (t1 - t0) / 1e6 << std::endl;
-  std::cout << GridLogDebug << ", allocations = "               << (t2 - t1) / 1e6 << std::endl;
-  std::cout << GridLogDebug << ", field strength = "            << (t3 - t2) / 1e6 << std::endl;
-  std::cout << GridLogDebug << ", fill clover = "               << (t4 - t3) / 1e6 << std::endl;
-  std::cout << GridLogDebug << ", convert = "                   << (t5 - t4) / 1e6 << std::endl;
-  std::cout << GridLogDebug << ", exponentiation = "            << (t6 - t5) / 1e6 << std::endl;
-  std::cout << GridLogDebug << ", boundaries = "                << (t7 - t6) / 1e6 << std::endl;
-	std::cout << GridLogDebug << ", inversions = "                << (t8 - t7) / 1e6 << std::endl;
-  std::cout << GridLogDebug << ", pick cbs = "                  << (t9 - t8) / 1e6 << std::endl;
-  std::cout << GridLogDebug << ", total = "                     << (t9 - t0) / 1e6 << std::endl;
+  std::cout << GridLogDebug << "allocations = "               << (t2 - t1) / 1e6 << std::endl;
+  std::cout << GridLogDebug << "field strength = "            << (t3 - t2) / 1e6 << std::endl;
+  std::cout << GridLogDebug << "fill clover = "               << (t4 - t3) / 1e6 << std::endl;
+  std::cout << GridLogDebug << "convert = "                   << (t5 - t4) / 1e6 << std::endl;
+  std::cout << GridLogDebug << "exponentiation = "            << (t6 - t5) / 1e6 << std::endl;
+  std::cout << GridLogDebug << "boundaries = "                << (t7 - t6) / 1e6 << std::endl;
+	std::cout << GridLogDebug << "inversions = "                << (t8 - t7) / 1e6 << std::endl;
+  std::cout << GridLogDebug << "pick cbs = "                  << (t9 - t8) / 1e6 << std::endl;
+  std::cout << GridLogDebug << "total = "                     << (t9 - t0) / 1e6 << std::endl;
 }
 
 NAMESPACE_END(Grid);

--- a/Grid/qcd/action/fermion/implementation/WilsonExpCloverFermionImplementation.h
+++ b/Grid/qcd/action/fermion/implementation/WilsonExpCloverFermionImplementation.h
@@ -165,7 +165,7 @@ void WilsonExpCloverFermion<Impl>::ImportGauge(const GaugeField &_Umu)
   // Add the twisted mass
   CloverFieldType T(CloverTerm.Grid());
   T = Zero();
-  autoView(T_v,T,AcceleratorWrite);
+  autoView(T_v,T,CpuWrite);
   thread_for(i, CloverTerm.Grid()->oSites(),
   {
     T_v[i]()(0, 0) = +twmass;

--- a/Grid/qcd/action/fermion/implementation/WilsonExpCloverFermionImplementation.h
+++ b/Grid/qcd/action/fermion/implementation/WilsonExpCloverFermionImplementation.h
@@ -166,7 +166,7 @@ void WilsonExpCloverFermion<Impl>::ImportGauge(const GaugeField &_Umu)
   CloverFieldType T(CloverTerm.Grid());
   T = Zero();
   autoView(T_v,T,AcceleratorWrite);
-  accelerator_for(i, CloverTerm.Grid()->oSites(),1,
+  thread_for(i, CloverTerm.Grid()->oSites(),
   {
     T_v[i]()(0, 0) = +twmass;
     T_v[i]()(1, 1) = +twmass;


### PR DESCRIPTION
modification for open boundary conditions corrected, timings are now send to GridLogDebug